### PR TITLE
readme: Fix command for config copy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ sudo docker-compose up -d
 - Copy the config.php
 ​
 ```
-docker exec -it docker-nextcloud-website_wordpress_1 cp wp-content/themes/next/config.php.sample wp-content/themes/next/config.php
+docker-compose exec wordpress cp wp-content/themes/next/config.php.sample wp-content/themes/next/config.php
 ```
 
 - Access the site at [localhost:8084](http://localhost:8084)


### PR DESCRIPTION
The old command was not working because it used an invalid container name (`docker-nextcloud-website` instead of `docker-nc-web`). Since I was already changing it, I changed it to use the `docker-compose` variant which should be independent of  the repository name.